### PR TITLE
Add gameBoard object

### DIFF
--- a/src/gameBoard.js
+++ b/src/gameBoard.js
@@ -1,0 +1,7 @@
+const gameBoard = {
+    element: document.querySelector('#game-board'),
+    height: 400,
+    width: 900,
+};
+
+export default gameBoard;


### PR DESCRIPTION
This object is used to store a reference to the game-board element and
its width and height.