### PR TITLE
Format answers to a max of 2 decimal places

### DIFF
--- a/src/modules/game.js
+++ b/src/modules/game.js
@@ -85,7 +85,7 @@ class Game {
         const selectedEnemy = this.enemies.find((enemy) => enemy.selected);
         if (!selectedEnemy) return;
 
-        const correctAnswer = selectedEnemy.question.answer.toString();
+        const correctAnswer = selectedEnemy.question.answer;
         const userAnswer = this.answerInput.value;
 
         if (userAnswer === correctAnswer) selectedEnemy.delete(this);

--- a/src/modules/questionGenerator.js
+++ b/src/modules/questionGenerator.js
@@ -48,6 +48,11 @@ const answerQuestion = (question) => {
     return answer;
 };
 
+const formatter = new Intl.NumberFormat('en-GB', {
+    maximumFractionDigits: 2,
+    useGrouping: false,
+});
+
 const questionGenerator = (difficulty) => {
     const operator = operatorSelector(difficulty);
     const questionText = `${questionNumberGenerator(
@@ -57,7 +62,7 @@ const questionGenerator = (difficulty) => {
 
     return {
         text: questionText,
-        answer,
+        answer: formatter.format(answer),
     };
 };
 


### PR DESCRIPTION
Add a formatter function to format question answers to a maximum of two
decimal places. This will be good for users as they wont have to work out
every decimal place of a answer, which might slow them down.